### PR TITLE
Change Prototyper GitHub URL

### DIFF
--- a/app/views/apps/show.html.erb
+++ b/app/views/apps/show.html.erb
@@ -74,7 +74,7 @@
       <%= render 'manage_releases' %>
     </div>
     <p class="extra_info">
-      Include the <a href="https://github.com/grafele/Prototyper" target="_blank">Prototyper framework</a> in your Xcode project to use marvel mockups inside your app.
+      Include the <a href="https://github.com/ls1intum/Prototyper" target="_blank">Prototyper framework</a> to send feedback to Prototyper and include mockups in your app.
     </p>
   </div>
   <div id="user_management" class="tab-pane fade">


### PR DESCRIPTION
A small PR to change the Prototyper GitHub URL to point to the Prototyper framework found at https://github.com/ls1intum/Prototyper.