### PR TITLE
wget gets now installed in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ ENV RAILS_ENV production
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y imagemagick libmagickcore-dev libmagickwand-dev tzdata && \
+    apt-get install -y imagemagick libmagickcore-dev libmagickwand-dev tzdata wget && \
     bundle install --deployment --without development test && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Wget is used to download the marvel prototype (https://github.com/ls1intum/prototyper_web/blob/5b2e2998f66adbefbc09871fa69b587c9d3392a3/app/helpers/releases_helper.rb#L410) and is not available in the container.